### PR TITLE
Add README.Rmd to knit README.md with formulas

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -1,0 +1,37 @@
+---
+output: github_document
+---
+
+<!-- README.md is knitted from README.Rmd. Please, edit README.Rmd file and re-knit -->
+
+# The-Art-of-Linear-Algebra
+Graphic notes on Gilbert Strang's "Linear Algebra for Everyone"
+
+The output file is "[The-Art-of-Linear-Algebra.pdf](The-Art-of-Linear-Algebra.pdf)"
+Japanese version "[The-Art-of-Linear-Algebra-j.pdf](The-Art-of-Linear-Algebra-j.pdf)"
+
+## Abstract
+I tried intuitive visualizations of important concepts introduced
+in "Linear Algebra for Everyone".
+
+This is aimed at promoting understanding of vector/matrix calculations
+and algorithms from the perspectives of matrix factorizations.
+They include Column-Row ($CR$), Gaussian Elimination ($LU$),
+Gram-Schmidt Orthogonalization ($QR$), Eigenvalues and Diagonalization ($Q \Lambda Q^T$),
+and Singular Value Decomposition ($U \Sigma V^T$).
+
+![5 Factorizations](5-Factorizations.png)
+
+Also includes other graphics.
+
+## Map of Eigenvalues
+
+![Map of Eigenvalues](MapofEigenvalues.png)
+
+- Avaialble in PDF "[MapofEigenvalues](MapofEigenvalues-v1.1.pdf)"
+
+## Matrix World
+
+![Matrix World](MatrixWorld.png)
+- Avaialble in PDF "[MatrixWorld](MatrixWorld-v1.4.2-LAFE.pdf)"
+

--- a/README.md
+++ b/README.md
@@ -1,18 +1,32 @@
-# The-Art-of-Linear-Algebra
-Graphic notes on Gilbert Strang's "Linear Algebra for Everyone"
 
-The output file is "[The-Art-of-Linear-Algebra.pdf](The-Art-of-Linear-Algebra.pdf)"
-Japanese version "[The-Art-of-Linear-Algebra-j.pdf](The-Art-of-Linear-Algebra-j.pdf)"
+<!-- README.md is knitted from README.Rmd. Please, edit README.Rmd file and re-knit -->
+
+# The-Art-of-Linear-Algebra
+
+Graphic notes on Gilbert Strang’s “Linear Algebra for Everyone”
+
+The output file is
+“[The-Art-of-Linear-Algebra.pdf](The-Art-of-Linear-Algebra.pdf)”
+Japanese version
+“[The-Art-of-Linear-Algebra-j.pdf](The-Art-of-Linear-Algebra-j.pdf)”
 
 ## Abstract
-I tried intuitive visualizations of important concepts introduced
-in "Linear Algebra for Everyone".
+
+I tried intuitive visualizations of important concepts introduced in
+“Linear Algebra for Everyone”.
 
 This is aimed at promoting understanding of vector/matrix calculations
-and algorithms from the perspectives of matrix factorizations.
-They include Column-Row ($CR$), Gaussian Elimination ($LU$),
-Gram-Schmidt Orthogonalization ($QR$), Eigenvalues and Diagonalization ($Q \Lambda Q^T$),
-and Singular Value Decomposition ($U \Sigma V^T$).
+and algorithms from the perspectives of matrix factorizations. They
+include Column-Row
+(![CR](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D&space;%5Cbg_white&space;CR "CR")),
+Gaussian Elimination
+(![LU](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D&space;%5Cbg_white&space;LU "LU")),
+Gram-Schmidt Orthogonalization
+(![QR](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D&space;%5Cbg_white&space;QR "QR")),
+Eigenvalues and Diagonalization
+(![Q \Lambda Q^T](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D&space;%5Cbg_white&space;Q%20%5CLambda%20Q%5ET "Q \Lambda Q^T")),
+and Singular Value Decomposition
+(![U \Sigma V^T](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D&space;%5Cbg_white&space;U%20%5CSigma%20V%5ET "U \Sigma V^T")).
 
 ![5 Factorizations](5-Factorizations.png)
 
@@ -22,10 +36,9 @@ Also includes other graphics.
 
 ![Map of Eigenvalues](MapofEigenvalues.png)
 
-- Avaialble in PDF "[MapofEigenvalues](MapofEigenvalues-v1.1.pdf)"
+-   Avaialble in PDF “[MapofEigenvalues](MapofEigenvalues-v1.1.pdf)”
 
 ## Matrix World
 
-![Matrix World](MatrixWorld.png)
-- Avaialble in PDF "[MatrixWorld](MatrixWorld-v1.4.2-LAFE.pdf)"
-
+![Matrix World](MatrixWorld.png) - Avaialble in PDF
+“[MatrixWorld](MatrixWorld-v1.4.2-LAFE.pdf)”


### PR DESCRIPTION
Thank you, Kenji, for the awesome resource! This PR is a small fix to properly show MathJax formulas. `README.Rmd` is the document knitted to `README.md` (output: github_document); the latter will contain rendered formulas. [Example of the result](https://github.com/mdozmorov/The-Art-of-Linear-Algebra/blob/main/README.md)